### PR TITLE
Fix curl install to use raw.githubusercontent.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terminal Setup for OS X with [Fish Shell](https://fishshell.com/), [Fisherman](h
 Can't wait to run the fish shell?  
 You can run the [install.sh](https://github.com/ellerbrock/tutorial-fish-shell-setup-osx/blob/master/install.sh) to install the [Fish Shell](https://fishshell.com/), [Fisherman](http://fisherman.sh/), [Powerline Fonts](https://github.com/powerline/fonts) and [iTerm2](https://www.iterm2.com/).
 
-`curl https://github.com/ellerbrock/tutorial-fish-shell-setup-osx/blob/master/install.sh | bash`
+`curl https://raw.githubusercontent.com/ellerbrock/fish-shell-setup-osx/master/install.sh | bash`
 
 ## iTerm2
 


### PR DESCRIPTION
GitHub has probably changed raw delivery URLs, because the quick install command fails:

```console
$ curl https://github.com/ellerbrock/tutorial-fish-shell-setup-osx/blob/master/install.sh | bash


  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   139    0   139    0     0    169      0 --:--:-- --:--:-- --:--:--   169
bash: line 1: syntax error near unexpected token `<'
bash: line 1: `<html><body>You are being <a href="https://github.com/ellerbrock/fish-shell-setup-osx/blob/master/install.sh">redirected</a>.</body></html>'
```

This PR fixes it.